### PR TITLE
Fix navigation bar topic rendering after plugster 1.0.14 bump

### DIFF
--- a/client-stack/modules/blog/navigation-bar.js
+++ b/client-stack/modules/blog/navigation-bar.js
@@ -21,7 +21,7 @@ class NavigationBarPlugster extends Plugster {
         let self = this;
         let itemOutlets = self._.menu.buildListItem(0, topic.id, topic, {
             label: {}
-        }, function(key, jsonData) {
+        }, 0, function(key, jsonData) {
             self.notifyTopicSelection(key);
         });
         itemOutlets.label.text(topic.name);


### PR DESCRIPTION
`buildListItem` gained an `atIndex` positional parameter in plugster 1.0.14, inserted before `itemClickCallback`. The old 5-arg call here was passing the click handler in the `atIndex` slot, so the handler was silently dropped and the row template was inserted with NaN coordinates; the returned outlets had no `label` and `addTopic` crashed on `itemOutlets.label.text(...)`.

Pass `0` explicitly for `atIndex` to preserve the previous prepend behaviour and put the callback back in the right slot.