### PR TITLE
Fix blog entry date label

### DIFF
--- a/client-stack/modules/blog/feed.js
+++ b/client-stack/modules/blog/feed.js
@@ -51,7 +51,7 @@ class FeedPlugster extends Plugster {
         });        
         
         itemOutlets.authorLabel.text(jsonpath.value(item, '$.author'));
-        itemOutlets.dateLabel.text(Date.parse(item.date).toString("MMMM dd, 2020 - HH:mm.ss"));
+        itemOutlets.dateLabel.text(Date.parse(item.date).toString("MMMM dd, yyyy - HH:mm:ss"));
     }
 
 }


### PR DESCRIPTION
The Datejs format string passed to toString() had the year hardcoded as the literal `2020` instead of `yyyy`, so every rendered date label on the blog has been showing year 2020 since day one — it only became obvious when posts dated 2026 showed up still labeled "2020".

Also normalise the time separator from `HH:mm.ss` to `HH:mm:ss`.

Sort order is unaffected; comparison continues to use the Date objects returned by Datejs's overridden Date.parse.