### PR TITLE
Append blog entries instead of prepending each one

### DIFF
--- a/client-stack/modules/blog/feed.js
+++ b/client-stack/modules/blog/feed.js
@@ -41,7 +41,7 @@ class FeedPlugster extends Plugster {
             content: {},
             authorLabel: {},
             dateLabel: {}
-        });
+        }, self._.articlesList.count());
         if(!itemOutlets) return null;
         itemOutlets.content.load(`/db/${jsonpath.value(item, '$.topic')}/${jsonpath.value(item, '$.fileName')}`, function(content) {
             this.innerHTML = new window.showdown.Converter().makeHtml(content);


### PR DESCRIPTION
The feed sorts articles newest-first and then renders them. Before plugster 1.0.14, buildListItem always prepended internally, so a "sort desc + prepend each" pattern accidentally produced "oldest at the top, newest at the bottom" — readers never noticed because there were only four posts, all close in time.

In 1.0.14 buildListItem accepts an `atIndex` argument (default 0 = prepend). Pass `count()` to append, so newest-first iteration produces newest-first DOM order. Same renderBlogEntry is used by the handleTopicSelection filter path, so that gets fixed in the same edit.